### PR TITLE
Change Spotless format to be closer to the IntelliJ default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,7 +97,7 @@ tasks.withType<DependencyUpdatesTask> {
 
 spotless {
     java {
-        googleJavaFormat()
+        palantirJavaFormat()
         formatAnnotations()
     }
 }

--- a/src/functional-test/java/uk/tw/energy/EndpointTest.java
+++ b/src/functional-test/java/uk/tw/energy/EndpointTest.java
@@ -23,89 +23,83 @@ import uk.tw.energy.domain.MeterReadings;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class)
 public class EndpointTest {
 
-  @Autowired private TestRestTemplate restTemplate;
+    @Autowired
+    private TestRestTemplate restTemplate;
 
-  private static HttpEntity<MeterReadings> toHttpEntity(MeterReadings meterReadings) {
-    HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(MediaType.APPLICATION_JSON);
-    return new HttpEntity<>(meterReadings, headers);
-  }
+    private static HttpEntity<MeterReadings> toHttpEntity(MeterReadings meterReadings) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<>(meterReadings, headers);
+    }
 
-  @Test
-  public void shouldStoreReadings() {
-    MeterReadings meterReadings = new MeterReadingsBuilder().generateElectricityReadings().build();
-    HttpEntity<MeterReadings> entity = toHttpEntity(meterReadings);
+    @Test
+    public void shouldStoreReadings() {
+        MeterReadings meterReadings =
+                new MeterReadingsBuilder().generateElectricityReadings().build();
+        HttpEntity<MeterReadings> entity = toHttpEntity(meterReadings);
 
-    ResponseEntity<String> response =
+        ResponseEntity<String> response = restTemplate.postForEntity("/readings/store", entity, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    public void givenMeterIdShouldReturnAMeterReadingAssociatedWithMeterId() {
+        String smartMeterId = "alice";
+        List<ElectricityReading> data = List.of(
+                new ElectricityReading(Instant.parse("2024-04-26T00:00:10.00Z"), new BigDecimal(10)),
+                new ElectricityReading(Instant.parse("2024-04-26T00:00:20.00Z"), new BigDecimal(20)),
+                new ElectricityReading(Instant.parse("2024-04-26T00:00:30.00Z"), new BigDecimal(30)));
+        populateReadingsForMeter(smartMeterId, data);
+
+        ResponseEntity<ElectricityReading[]> response =
+                restTemplate.getForEntity("/readings/read/" + smartMeterId, ElectricityReading[].class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(Arrays.asList(response.getBody())).isEqualTo(data);
+    }
+
+    @Test
+    public void shouldCalculateAllPrices() {
+        String smartMeterId = "bob";
+        List<ElectricityReading> data = List.of(
+                new ElectricityReading(Instant.parse("2024-04-26T00:00:10.00Z"), new BigDecimal(10)),
+                new ElectricityReading(Instant.parse("2024-04-26T00:00:20.00Z"), new BigDecimal(20)),
+                new ElectricityReading(Instant.parse("2024-04-26T00:00:30.00Z"), new BigDecimal(30)));
+        populateReadingsForMeter(smartMeterId, data);
+
+        ResponseEntity<CompareAllResponse> response =
+                restTemplate.getForEntity("/price-plans/compare-all/" + smartMeterId, CompareAllResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody())
+                .isEqualTo(new CompareAllResponse(
+                        Map.of("price-plan-0", 36000, "price-plan-1", 7200, "price-plan-2", 3600), null));
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void givenMeterIdAndLimitShouldReturnRecommendedCheapestPricePlans() {
+        String smartMeterId = "jane";
+        List<ElectricityReading> data = List.of(
+                new ElectricityReading(Instant.parse("2024-04-26T00:00:10.00Z"), new BigDecimal(10)),
+                new ElectricityReading(Instant.parse("2024-04-26T00:00:20.00Z"), new BigDecimal(20)),
+                new ElectricityReading(Instant.parse("2024-04-26T00:00:30.00Z"), new BigDecimal(30)));
+        populateReadingsForMeter(smartMeterId, data);
+
+        ResponseEntity<Map[]> response =
+                restTemplate.getForEntity("/price-plans/recommend/" + smartMeterId + "?limit=2", Map[].class);
+
+        assertThat(response.getBody()).containsExactly(Map.of("price-plan-2", 3600), Map.of("price-plan-1", 7200));
+    }
+
+    private void populateReadingsForMeter(String smartMeterId, List<ElectricityReading> data) {
+        MeterReadings readings = new MeterReadings(smartMeterId, data);
+
+        HttpEntity<MeterReadings> entity = toHttpEntity(readings);
         restTemplate.postForEntity("/readings/store", entity, String.class);
+    }
 
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-  }
-
-  @SuppressWarnings("DataFlowIssue")
-  @Test
-  public void givenMeterIdShouldReturnAMeterReadingAssociatedWithMeterId() {
-    String smartMeterId = "alice";
-    List<ElectricityReading> data =
-        List.of(
-            new ElectricityReading(Instant.parse("2024-04-26T00:00:10.00Z"), new BigDecimal(10)),
-            new ElectricityReading(Instant.parse("2024-04-26T00:00:20.00Z"), new BigDecimal(20)),
-            new ElectricityReading(Instant.parse("2024-04-26T00:00:30.00Z"), new BigDecimal(30)));
-    populateReadingsForMeter(smartMeterId, data);
-
-    ResponseEntity<ElectricityReading[]> response =
-        restTemplate.getForEntity("/readings/read/" + smartMeterId, ElectricityReading[].class);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(Arrays.asList(response.getBody())).isEqualTo(data);
-  }
-
-  @Test
-  public void shouldCalculateAllPrices() {
-    String smartMeterId = "bob";
-    List<ElectricityReading> data =
-        List.of(
-            new ElectricityReading(Instant.parse("2024-04-26T00:00:10.00Z"), new BigDecimal(10)),
-            new ElectricityReading(Instant.parse("2024-04-26T00:00:20.00Z"), new BigDecimal(20)),
-            new ElectricityReading(Instant.parse("2024-04-26T00:00:30.00Z"), new BigDecimal(30)));
-    populateReadingsForMeter(smartMeterId, data);
-
-    ResponseEntity<CompareAllResponse> response =
-        restTemplate.getForEntity(
-            "/price-plans/compare-all/" + smartMeterId, CompareAllResponse.class);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody())
-        .isEqualTo(
-            new CompareAllResponse(
-                Map.of("price-plan-0", 36000, "price-plan-1", 7200, "price-plan-2", 3600), null));
-  }
-
-  @SuppressWarnings("rawtypes")
-  @Test
-  public void givenMeterIdAndLimitShouldReturnRecommendedCheapestPricePlans() {
-    String smartMeterId = "jane";
-    List<ElectricityReading> data =
-        List.of(
-            new ElectricityReading(Instant.parse("2024-04-26T00:00:10.00Z"), new BigDecimal(10)),
-            new ElectricityReading(Instant.parse("2024-04-26T00:00:20.00Z"), new BigDecimal(20)),
-            new ElectricityReading(Instant.parse("2024-04-26T00:00:30.00Z"), new BigDecimal(30)));
-    populateReadingsForMeter(smartMeterId, data);
-
-    ResponseEntity<Map[]> response =
-        restTemplate.getForEntity(
-            "/price-plans/recommend/" + smartMeterId + "?limit=2", Map[].class);
-
-    assertThat(response.getBody())
-        .containsExactly(Map.of("price-plan-2", 3600), Map.of("price-plan-1", 7200));
-  }
-
-  private void populateReadingsForMeter(String smartMeterId, List<ElectricityReading> data) {
-    MeterReadings readings = new MeterReadings(smartMeterId, data);
-
-    HttpEntity<MeterReadings> entity = toHttpEntity(readings);
-    restTemplate.postForEntity("/readings/store", entity, String.class);
-  }
-
-  record CompareAllResponse(Map<String, Integer> pricePlanComparisons, String pricePlanId) {}
+    record CompareAllResponse(Map<String, Integer> pricePlanComparisons, String pricePlanId) {}
 }

--- a/src/main/java/uk/tw/energy/App.java
+++ b/src/main/java/uk/tw/energy/App.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class App {
 
-  public static void main(String[] args) {
-    SpringApplication.run(App.class);
-  }
+    public static void main(String[] args) {
+        SpringApplication.run(App.class);
+    }
 }

--- a/src/main/java/uk/tw/energy/SeedingApplicationDataConfiguration.java
+++ b/src/main/java/uk/tw/energy/SeedingApplicationDataConfiguration.java
@@ -20,52 +20,45 @@ import uk.tw.energy.generator.ElectricityReadingsGenerator;
 @Configuration
 public class SeedingApplicationDataConfiguration {
 
-  private static final String MOST_EVIL_PRICE_PLAN_ID = "price-plan-0";
-  private static final String RENEWABLES_PRICE_PLAN_ID = "price-plan-1";
-  private static final String STANDARD_PRICE_PLAN_ID = "price-plan-2";
+    private static final String MOST_EVIL_PRICE_PLAN_ID = "price-plan-0";
+    private static final String RENEWABLES_PRICE_PLAN_ID = "price-plan-1";
+    private static final String STANDARD_PRICE_PLAN_ID = "price-plan-2";
 
-  @Bean
-  public List<PricePlan> pricePlans() {
-    final List<PricePlan> pricePlans = new ArrayList<>();
-    pricePlans.add(
-        new PricePlan(
-            MOST_EVIL_PRICE_PLAN_ID, "Dr Evil's Dark Energy", BigDecimal.TEN, emptyList()));
-    pricePlans.add(
-        new PricePlan(
-            RENEWABLES_PRICE_PLAN_ID, "The Green Eco", BigDecimal.valueOf(2), emptyList()));
-    pricePlans.add(
-        new PricePlan(STANDARD_PRICE_PLAN_ID, "Power for Everyone", BigDecimal.ONE, emptyList()));
-    return pricePlans;
-  }
+    @Bean
+    public List<PricePlan> pricePlans() {
+        final List<PricePlan> pricePlans = new ArrayList<>();
+        pricePlans.add(new PricePlan(MOST_EVIL_PRICE_PLAN_ID, "Dr Evil's Dark Energy", BigDecimal.TEN, emptyList()));
+        pricePlans.add(new PricePlan(RENEWABLES_PRICE_PLAN_ID, "The Green Eco", BigDecimal.valueOf(2), emptyList()));
+        pricePlans.add(new PricePlan(STANDARD_PRICE_PLAN_ID, "Power for Everyone", BigDecimal.ONE, emptyList()));
+        return pricePlans;
+    }
 
-  @Bean
-  public Map<String, List<ElectricityReading>> perMeterElectricityReadings() {
-    final Map<String, List<ElectricityReading>> readings = new HashMap<>();
-    final ElectricityReadingsGenerator electricityReadingsGenerator =
-        new ElectricityReadingsGenerator();
-    smartMeterToPricePlanAccounts()
-        .keySet()
-        .forEach(
-            smartMeterId -> readings.put(smartMeterId, electricityReadingsGenerator.generate(20)));
-    return readings;
-  }
+    @Bean
+    public Map<String, List<ElectricityReading>> perMeterElectricityReadings() {
+        final Map<String, List<ElectricityReading>> readings = new HashMap<>();
+        final ElectricityReadingsGenerator electricityReadingsGenerator = new ElectricityReadingsGenerator();
+        smartMeterToPricePlanAccounts()
+                .keySet()
+                .forEach(smartMeterId -> readings.put(smartMeterId, electricityReadingsGenerator.generate(20)));
+        return readings;
+    }
 
-  @Bean
-  public Map<String, String> smartMeterToPricePlanAccounts() {
-    final Map<String, String> smartMeterToPricePlanAccounts = new HashMap<>();
-    smartMeterToPricePlanAccounts.put("smart-meter-0", MOST_EVIL_PRICE_PLAN_ID);
-    smartMeterToPricePlanAccounts.put("smart-meter-1", RENEWABLES_PRICE_PLAN_ID);
-    smartMeterToPricePlanAccounts.put("smart-meter-2", MOST_EVIL_PRICE_PLAN_ID);
-    smartMeterToPricePlanAccounts.put("smart-meter-3", STANDARD_PRICE_PLAN_ID);
-    smartMeterToPricePlanAccounts.put("smart-meter-4", RENEWABLES_PRICE_PLAN_ID);
-    return smartMeterToPricePlanAccounts;
-  }
+    @Bean
+    public Map<String, String> smartMeterToPricePlanAccounts() {
+        final Map<String, String> smartMeterToPricePlanAccounts = new HashMap<>();
+        smartMeterToPricePlanAccounts.put("smart-meter-0", MOST_EVIL_PRICE_PLAN_ID);
+        smartMeterToPricePlanAccounts.put("smart-meter-1", RENEWABLES_PRICE_PLAN_ID);
+        smartMeterToPricePlanAccounts.put("smart-meter-2", MOST_EVIL_PRICE_PLAN_ID);
+        smartMeterToPricePlanAccounts.put("smart-meter-3", STANDARD_PRICE_PLAN_ID);
+        smartMeterToPricePlanAccounts.put("smart-meter-4", RENEWABLES_PRICE_PLAN_ID);
+        return smartMeterToPricePlanAccounts;
+    }
 
-  @Bean
-  @Primary
-  public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
-    ObjectMapper objectMapper = builder.createXmlMapper(false).build();
-    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    return objectMapper;
-  }
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
+        ObjectMapper objectMapper = builder.createXmlMapper(false).build();
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        return objectMapper;
+    }
 }

--- a/src/main/java/uk/tw/energy/controller/MeterReadingController.java
+++ b/src/main/java/uk/tw/energy/controller/MeterReadingController.java
@@ -18,36 +18,35 @@ import uk.tw.energy.service.MeterReadingService;
 @RequestMapping("/readings")
 public class MeterReadingController {
 
-  private final MeterReadingService meterReadingService;
+    private final MeterReadingService meterReadingService;
 
-  public MeterReadingController(MeterReadingService meterReadingService) {
-    this.meterReadingService = meterReadingService;
-  }
-
-  @PostMapping("/store")
-  public ResponseEntity storeReadings(@RequestBody MeterReadings meterReadings) {
-    if (!isMeterReadingsValid(meterReadings)) {
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    public MeterReadingController(MeterReadingService meterReadingService) {
+        this.meterReadingService = meterReadingService;
     }
-    meterReadingService.storeReadings(
-        meterReadings.smartMeterId(), meterReadings.electricityReadings());
-    return ResponseEntity.ok().build();
-  }
 
-  private boolean isMeterReadingsValid(MeterReadings meterReadings) {
-    String smartMeterId = meterReadings.smartMeterId();
-    List<ElectricityReading> electricityReadings = meterReadings.electricityReadings();
-    return smartMeterId != null
-        && !smartMeterId.isEmpty()
-        && electricityReadings != null
-        && !electricityReadings.isEmpty();
-  }
+    @PostMapping("/store")
+    public ResponseEntity storeReadings(@RequestBody MeterReadings meterReadings) {
+        if (!isMeterReadingsValid(meterReadings)) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+        meterReadingService.storeReadings(meterReadings.smartMeterId(), meterReadings.electricityReadings());
+        return ResponseEntity.ok().build();
+    }
 
-  @GetMapping("/read/{smartMeterId}")
-  public ResponseEntity readReadings(@PathVariable String smartMeterId) {
-    Optional<List<ElectricityReading>> readings = meterReadingService.getReadings(smartMeterId);
-    return readings.isPresent()
-        ? ResponseEntity.ok(readings.get())
-        : ResponseEntity.notFound().build();
-  }
+    private boolean isMeterReadingsValid(MeterReadings meterReadings) {
+        String smartMeterId = meterReadings.smartMeterId();
+        List<ElectricityReading> electricityReadings = meterReadings.electricityReadings();
+        return smartMeterId != null
+                && !smartMeterId.isEmpty()
+                && electricityReadings != null
+                && !electricityReadings.isEmpty();
+    }
+
+    @GetMapping("/read/{smartMeterId}")
+    public ResponseEntity readReadings(@PathVariable String smartMeterId) {
+        Optional<List<ElectricityReading>> readings = meterReadingService.getReadings(smartMeterId);
+        return readings.isPresent()
+                ? ResponseEntity.ok(readings.get())
+                : ResponseEntity.notFound().build();
+    }
 }

--- a/src/main/java/uk/tw/energy/controller/PricePlanComparatorController.java
+++ b/src/main/java/uk/tw/energy/controller/PricePlanComparatorController.java
@@ -20,56 +20,53 @@ import uk.tw.energy.service.PricePlanService;
 @RequestMapping("/price-plans")
 public class PricePlanComparatorController {
 
-  public static final String PRICE_PLAN_ID_KEY = "pricePlanId";
-  public static final String PRICE_PLAN_COMPARISONS_KEY = "pricePlanComparisons";
-  private final PricePlanService pricePlanService;
-  private final AccountService accountService;
+    public static final String PRICE_PLAN_ID_KEY = "pricePlanId";
+    public static final String PRICE_PLAN_COMPARISONS_KEY = "pricePlanComparisons";
+    private final PricePlanService pricePlanService;
+    private final AccountService accountService;
 
-  public PricePlanComparatorController(
-      PricePlanService pricePlanService, AccountService accountService) {
-    this.pricePlanService = pricePlanService;
-    this.accountService = accountService;
-  }
-
-  @GetMapping("/compare-all/{smartMeterId}")
-  public ResponseEntity<Map<String, Object>> calculatedCostForEachPricePlan(
-      @PathVariable String smartMeterId) {
-    String pricePlanId = accountService.getPricePlanIdForSmartMeterId(smartMeterId);
-    Optional<Map<String, BigDecimal>> consumptionsForPricePlans =
-        pricePlanService.getConsumptionCostOfElectricityReadingsForEachPricePlan(smartMeterId);
-
-    if (!consumptionsForPricePlans.isPresent()) {
-      return ResponseEntity.notFound().build();
+    public PricePlanComparatorController(PricePlanService pricePlanService, AccountService accountService) {
+        this.pricePlanService = pricePlanService;
+        this.accountService = accountService;
     }
 
-    Map<String, Object> pricePlanComparisons = new HashMap<>();
-    pricePlanComparisons.put(PRICE_PLAN_ID_KEY, pricePlanId);
-    pricePlanComparisons.put(PRICE_PLAN_COMPARISONS_KEY, consumptionsForPricePlans.get());
+    @GetMapping("/compare-all/{smartMeterId}")
+    public ResponseEntity<Map<String, Object>> calculatedCostForEachPricePlan(@PathVariable String smartMeterId) {
+        String pricePlanId = accountService.getPricePlanIdForSmartMeterId(smartMeterId);
+        Optional<Map<String, BigDecimal>> consumptionsForPricePlans =
+                pricePlanService.getConsumptionCostOfElectricityReadingsForEachPricePlan(smartMeterId);
 
-    return consumptionsForPricePlans.isPresent()
-        ? ResponseEntity.ok(pricePlanComparisons)
-        : ResponseEntity.notFound().build();
-  }
+        if (!consumptionsForPricePlans.isPresent()) {
+            return ResponseEntity.notFound().build();
+        }
 
-  @GetMapping("/recommend/{smartMeterId}")
-  public ResponseEntity<List<Map.Entry<String, BigDecimal>>> recommendCheapestPricePlans(
-      @PathVariable String smartMeterId,
-      @RequestParam(value = "limit", required = false) Integer limit) {
-    Optional<Map<String, BigDecimal>> consumptionsForPricePlans =
-        pricePlanService.getConsumptionCostOfElectricityReadingsForEachPricePlan(smartMeterId);
+        Map<String, Object> pricePlanComparisons = new HashMap<>();
+        pricePlanComparisons.put(PRICE_PLAN_ID_KEY, pricePlanId);
+        pricePlanComparisons.put(PRICE_PLAN_COMPARISONS_KEY, consumptionsForPricePlans.get());
 
-    if (!consumptionsForPricePlans.isPresent()) {
-      return ResponseEntity.notFound().build();
+        return consumptionsForPricePlans.isPresent()
+                ? ResponseEntity.ok(pricePlanComparisons)
+                : ResponseEntity.notFound().build();
     }
 
-    List<Map.Entry<String, BigDecimal>> recommendations =
-        new ArrayList<>(consumptionsForPricePlans.get().entrySet());
-    recommendations.sort(Comparator.comparing(Map.Entry::getValue));
+    @GetMapping("/recommend/{smartMeterId}")
+    public ResponseEntity<List<Map.Entry<String, BigDecimal>>> recommendCheapestPricePlans(
+            @PathVariable String smartMeterId, @RequestParam(value = "limit", required = false) Integer limit) {
+        Optional<Map<String, BigDecimal>> consumptionsForPricePlans =
+                pricePlanService.getConsumptionCostOfElectricityReadingsForEachPricePlan(smartMeterId);
 
-    if (limit != null && limit < recommendations.size()) {
-      recommendations = recommendations.subList(0, limit);
+        if (!consumptionsForPricePlans.isPresent()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        List<Map.Entry<String, BigDecimal>> recommendations =
+                new ArrayList<>(consumptionsForPricePlans.get().entrySet());
+        recommendations.sort(Comparator.comparing(Map.Entry::getValue));
+
+        if (limit != null && limit < recommendations.size()) {
+            recommendations = recommendations.subList(0, limit);
+        }
+
+        return ResponseEntity.ok(recommendations);
     }
-
-    return ResponseEntity.ok(recommendations);
-  }
 }

--- a/src/main/java/uk/tw/energy/domain/PricePlan.java
+++ b/src/main/java/uk/tw/energy/domain/PricePlan.java
@@ -7,50 +7,47 @@ import java.util.List;
 
 public class PricePlan {
 
-  private final String energySupplier;
-  private final String planName;
-  private final BigDecimal unitRate; // unit price per kWh
-  private final List<PeakTimeMultiplier> peakTimeMultipliers;
+    private final String energySupplier;
+    private final String planName;
+    private final BigDecimal unitRate; // unit price per kWh
+    private final List<PeakTimeMultiplier> peakTimeMultipliers;
 
-  public PricePlan(
-      String planName,
-      String energySupplier,
-      BigDecimal unitRate,
-      List<PeakTimeMultiplier> peakTimeMultipliers) {
-    this.planName = planName;
-    this.energySupplier = energySupplier;
-    this.unitRate = unitRate;
-    this.peakTimeMultipliers = peakTimeMultipliers;
-  }
-
-  public String getEnergySupplier() {
-    return energySupplier;
-  }
-
-  public String getPlanName() {
-    return planName;
-  }
-
-  public BigDecimal getUnitRate() {
-    return unitRate;
-  }
-
-  public BigDecimal getPrice(LocalDateTime dateTime) {
-    return peakTimeMultipliers.stream()
-        .filter(multiplier -> multiplier.dayOfWeek.equals(dateTime.getDayOfWeek()))
-        .findFirst()
-        .map(multiplier -> unitRate.multiply(multiplier.multiplier))
-        .orElse(unitRate);
-  }
-
-  static class PeakTimeMultiplier {
-
-    DayOfWeek dayOfWeek;
-    BigDecimal multiplier;
-
-    public PeakTimeMultiplier(DayOfWeek dayOfWeek, BigDecimal multiplier) {
-      this.dayOfWeek = dayOfWeek;
-      this.multiplier = multiplier;
+    public PricePlan(
+            String planName, String energySupplier, BigDecimal unitRate, List<PeakTimeMultiplier> peakTimeMultipliers) {
+        this.planName = planName;
+        this.energySupplier = energySupplier;
+        this.unitRate = unitRate;
+        this.peakTimeMultipliers = peakTimeMultipliers;
     }
-  }
+
+    public String getEnergySupplier() {
+        return energySupplier;
+    }
+
+    public String getPlanName() {
+        return planName;
+    }
+
+    public BigDecimal getUnitRate() {
+        return unitRate;
+    }
+
+    public BigDecimal getPrice(LocalDateTime dateTime) {
+        return peakTimeMultipliers.stream()
+                .filter(multiplier -> multiplier.dayOfWeek.equals(dateTime.getDayOfWeek()))
+                .findFirst()
+                .map(multiplier -> unitRate.multiply(multiplier.multiplier))
+                .orElse(unitRate);
+    }
+
+    static class PeakTimeMultiplier {
+
+        DayOfWeek dayOfWeek;
+        BigDecimal multiplier;
+
+        public PeakTimeMultiplier(DayOfWeek dayOfWeek, BigDecimal multiplier) {
+            this.dayOfWeek = dayOfWeek;
+            this.multiplier = multiplier;
+        }
+    }
 }

--- a/src/main/java/uk/tw/energy/generator/ElectricityReadingsGenerator.java
+++ b/src/main/java/uk/tw/energy/generator/ElectricityReadingsGenerator.java
@@ -11,21 +11,19 @@ import uk.tw.energy.domain.ElectricityReading;
 
 public class ElectricityReadingsGenerator {
 
-  public List<ElectricityReading> generate(int number) {
-    List<ElectricityReading> readings = new ArrayList<>();
-    Instant now = Instant.now();
+    public List<ElectricityReading> generate(int number) {
+        List<ElectricityReading> readings = new ArrayList<>();
+        Instant now = Instant.now();
 
-    Random readingRandomiser = new Random();
-    for (int i = 0; i < number; i++) {
-      double positiveRandomValue = Math.abs(readingRandomiser.nextGaussian());
-      BigDecimal randomReading =
-          BigDecimal.valueOf(positiveRandomValue).setScale(4, RoundingMode.CEILING);
-      ElectricityReading electricityReading =
-          new ElectricityReading(now.minusSeconds(i * 10L), randomReading);
-      readings.add(electricityReading);
+        Random readingRandomiser = new Random();
+        for (int i = 0; i < number; i++) {
+            double positiveRandomValue = Math.abs(readingRandomiser.nextGaussian());
+            BigDecimal randomReading = BigDecimal.valueOf(positiveRandomValue).setScale(4, RoundingMode.CEILING);
+            ElectricityReading electricityReading = new ElectricityReading(now.minusSeconds(i * 10L), randomReading);
+            readings.add(electricityReading);
+        }
+
+        readings.sort(Comparator.comparing(ElectricityReading::time));
+        return readings;
     }
-
-    readings.sort(Comparator.comparing(ElectricityReading::time));
-    return readings;
-  }
 }

--- a/src/main/java/uk/tw/energy/service/AccountService.java
+++ b/src/main/java/uk/tw/energy/service/AccountService.java
@@ -6,13 +6,13 @@ import org.springframework.stereotype.Service;
 @Service
 public class AccountService {
 
-  private final Map<String, String> smartMeterToPricePlanAccounts;
+    private final Map<String, String> smartMeterToPricePlanAccounts;
 
-  public AccountService(Map<String, String> smartMeterToPricePlanAccounts) {
-    this.smartMeterToPricePlanAccounts = smartMeterToPricePlanAccounts;
-  }
+    public AccountService(Map<String, String> smartMeterToPricePlanAccounts) {
+        this.smartMeterToPricePlanAccounts = smartMeterToPricePlanAccounts;
+    }
 
-  public String getPricePlanIdForSmartMeterId(String smartMeterId) {
-    return smartMeterToPricePlanAccounts.get(smartMeterId);
-  }
+    public String getPricePlanIdForSmartMeterId(String smartMeterId) {
+        return smartMeterToPricePlanAccounts.get(smartMeterId);
+    }
 }

--- a/src/main/java/uk/tw/energy/service/MeterReadingService.java
+++ b/src/main/java/uk/tw/energy/service/MeterReadingService.java
@@ -10,20 +10,20 @@ import uk.tw.energy.domain.ElectricityReading;
 @Service
 public class MeterReadingService {
 
-  private final Map<String, List<ElectricityReading>> meterAssociatedReadings;
+    private final Map<String, List<ElectricityReading>> meterAssociatedReadings;
 
-  public MeterReadingService(Map<String, List<ElectricityReading>> meterAssociatedReadings) {
-    this.meterAssociatedReadings = meterAssociatedReadings;
-  }
-
-  public Optional<List<ElectricityReading>> getReadings(String smartMeterId) {
-    return Optional.ofNullable(meterAssociatedReadings.get(smartMeterId));
-  }
-
-  public void storeReadings(String smartMeterId, List<ElectricityReading> electricityReadings) {
-    if (!meterAssociatedReadings.containsKey(smartMeterId)) {
-      meterAssociatedReadings.put(smartMeterId, new ArrayList<>());
+    public MeterReadingService(Map<String, List<ElectricityReading>> meterAssociatedReadings) {
+        this.meterAssociatedReadings = meterAssociatedReadings;
     }
-    meterAssociatedReadings.get(smartMeterId).addAll(electricityReadings);
-  }
+
+    public Optional<List<ElectricityReading>> getReadings(String smartMeterId) {
+        return Optional.ofNullable(meterAssociatedReadings.get(smartMeterId));
+    }
+
+    public void storeReadings(String smartMeterId, List<ElectricityReading> electricityReadings) {
+        if (!meterAssociatedReadings.containsKey(smartMeterId)) {
+            meterAssociatedReadings.put(smartMeterId, new ArrayList<>());
+        }
+        meterAssociatedReadings.get(smartMeterId).addAll(electricityReadings);
+    }
 }

--- a/src/main/java/uk/tw/energy/service/PricePlanService.java
+++ b/src/main/java/uk/tw/energy/service/PricePlanService.java
@@ -15,56 +15,51 @@ import uk.tw.energy.domain.PricePlan;
 @Service
 public class PricePlanService {
 
-  private final List<PricePlan> pricePlans;
-  private final MeterReadingService meterReadingService;
+    private final List<PricePlan> pricePlans;
+    private final MeterReadingService meterReadingService;
 
-  public PricePlanService(List<PricePlan> pricePlans, MeterReadingService meterReadingService) {
-    this.pricePlans = pricePlans;
-    this.meterReadingService = meterReadingService;
-  }
-
-  public Optional<Map<String, BigDecimal>> getConsumptionCostOfElectricityReadingsForEachPricePlan(
-      String smartMeterId) {
-    Optional<List<ElectricityReading>> electricityReadings =
-        meterReadingService.getReadings(smartMeterId);
-
-    if (!electricityReadings.isPresent()) {
-      return Optional.empty();
+    public PricePlanService(List<PricePlan> pricePlans, MeterReadingService meterReadingService) {
+        this.pricePlans = pricePlans;
+        this.meterReadingService = meterReadingService;
     }
 
-    return Optional.of(
-        pricePlans.stream()
-            .collect(
-                Collectors.toMap(
-                    PricePlan::getPlanName, t -> calculateCost(electricityReadings.get(), t))));
-  }
+    public Optional<Map<String, BigDecimal>> getConsumptionCostOfElectricityReadingsForEachPricePlan(
+            String smartMeterId) {
+        Optional<List<ElectricityReading>> electricityReadings = meterReadingService.getReadings(smartMeterId);
 
-  private BigDecimal calculateCost(
-      List<ElectricityReading> electricityReadings, PricePlan pricePlan) {
-    BigDecimal average = calculateAverageReading(electricityReadings);
-    BigDecimal timeElapsed = calculateTimeElapsed(electricityReadings);
+        if (!electricityReadings.isPresent()) {
+            return Optional.empty();
+        }
 
-    BigDecimal averagedCost = average.divide(timeElapsed, RoundingMode.HALF_UP);
-    return averagedCost.multiply(pricePlan.getUnitRate());
-  }
+        return Optional.of(pricePlans.stream()
+                .collect(Collectors.toMap(PricePlan::getPlanName, t -> calculateCost(electricityReadings.get(), t))));
+    }
 
-  private BigDecimal calculateAverageReading(List<ElectricityReading> electricityReadings) {
-    BigDecimal summedReadings =
-        electricityReadings.stream()
-            .map(ElectricityReading::reading)
-            .reduce(BigDecimal.ZERO, (reading, accumulator) -> reading.add(accumulator));
+    private BigDecimal calculateCost(List<ElectricityReading> electricityReadings, PricePlan pricePlan) {
+        BigDecimal average = calculateAverageReading(electricityReadings);
+        BigDecimal timeElapsed = calculateTimeElapsed(electricityReadings);
 
-    return summedReadings.divide(
-        BigDecimal.valueOf(electricityReadings.size()), RoundingMode.HALF_UP);
-  }
+        BigDecimal averagedCost = average.divide(timeElapsed, RoundingMode.HALF_UP);
+        return averagedCost.multiply(pricePlan.getUnitRate());
+    }
 
-  private BigDecimal calculateTimeElapsed(List<ElectricityReading> electricityReadings) {
-    ElectricityReading first =
-        electricityReadings.stream().min(Comparator.comparing(ElectricityReading::time)).get();
+    private BigDecimal calculateAverageReading(List<ElectricityReading> electricityReadings) {
+        BigDecimal summedReadings = electricityReadings.stream()
+                .map(ElectricityReading::reading)
+                .reduce(BigDecimal.ZERO, (reading, accumulator) -> reading.add(accumulator));
 
-    ElectricityReading last =
-        electricityReadings.stream().max(Comparator.comparing(ElectricityReading::time)).get();
+        return summedReadings.divide(BigDecimal.valueOf(electricityReadings.size()), RoundingMode.HALF_UP);
+    }
 
-    return BigDecimal.valueOf(Duration.between(first.time(), last.time()).getSeconds() / 3600.0);
-  }
+    private BigDecimal calculateTimeElapsed(List<ElectricityReading> electricityReadings) {
+        ElectricityReading first = electricityReadings.stream()
+                .min(Comparator.comparing(ElectricityReading::time))
+                .get();
+
+        ElectricityReading last = electricityReadings.stream()
+                .max(Comparator.comparing(ElectricityReading::time))
+                .get();
+
+        return BigDecimal.valueOf(Duration.between(first.time(), last.time()).getSeconds() / 3600.0);
+    }
 }

--- a/src/test/java/uk/tw/energy/builders/MeterReadingsBuilder.java
+++ b/src/test/java/uk/tw/energy/builders/MeterReadingsBuilder.java
@@ -8,27 +8,27 @@ import uk.tw.energy.generator.ElectricityReadingsGenerator;
 
 public class MeterReadingsBuilder {
 
-  private static final String DEFAULT_METER_ID = "id";
+    private static final String DEFAULT_METER_ID = "id";
 
-  private String smartMeterId = DEFAULT_METER_ID;
-  private List<ElectricityReading> electricityReadings = new ArrayList<>();
+    private String smartMeterId = DEFAULT_METER_ID;
+    private List<ElectricityReading> electricityReadings = new ArrayList<>();
 
-  public MeterReadingsBuilder setSmartMeterId(String smartMeterId) {
-    this.smartMeterId = smartMeterId;
-    return this;
-  }
+    public MeterReadingsBuilder setSmartMeterId(String smartMeterId) {
+        this.smartMeterId = smartMeterId;
+        return this;
+    }
 
-  public MeterReadingsBuilder generateElectricityReadings() {
-    return generateElectricityReadings(5);
-  }
+    public MeterReadingsBuilder generateElectricityReadings() {
+        return generateElectricityReadings(5);
+    }
 
-  public MeterReadingsBuilder generateElectricityReadings(int number) {
-    ElectricityReadingsGenerator readingsBuilder = new ElectricityReadingsGenerator();
-    this.electricityReadings = readingsBuilder.generate(number);
-    return this;
-  }
+    public MeterReadingsBuilder generateElectricityReadings(int number) {
+        ElectricityReadingsGenerator readingsBuilder = new ElectricityReadingsGenerator();
+        this.electricityReadings = readingsBuilder.generate(number);
+        return this;
+    }
 
-  public MeterReadings build() {
-    return new MeterReadings(smartMeterId, electricityReadings);
-  }
+    public MeterReadings build() {
+        return new MeterReadings(smartMeterId, electricityReadings);
+    }
 }

--- a/src/test/java/uk/tw/energy/controller/MeterReadingControllerTest.java
+++ b/src/test/java/uk/tw/energy/controller/MeterReadingControllerTest.java
@@ -16,83 +16,81 @@ import uk.tw.energy.service.MeterReadingService;
 
 public class MeterReadingControllerTest {
 
-  private static final String SMART_METER_ID = "10101010";
-  private MeterReadingController meterReadingController;
-  private MeterReadingService meterReadingService;
+    private static final String SMART_METER_ID = "10101010";
+    private MeterReadingController meterReadingController;
+    private MeterReadingService meterReadingService;
 
-  @BeforeEach
-  public void setUp() {
-    this.meterReadingService = new MeterReadingService(new HashMap<>());
-    this.meterReadingController = new MeterReadingController(meterReadingService);
-  }
+    @BeforeEach
+    public void setUp() {
+        this.meterReadingService = new MeterReadingService(new HashMap<>());
+        this.meterReadingController = new MeterReadingController(meterReadingService);
+    }
 
-  @Test
-  public void givenNoMeterIdIsSuppliedWhenStoringShouldReturnErrorResponse() {
-    MeterReadings meterReadings = new MeterReadings(null, Collections.emptyList());
-    assertThat(meterReadingController.storeReadings(meterReadings).getStatusCode())
-        .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-  }
+    @Test
+    public void givenNoMeterIdIsSuppliedWhenStoringShouldReturnErrorResponse() {
+        MeterReadings meterReadings = new MeterReadings(null, Collections.emptyList());
+        assertThat(meterReadingController.storeReadings(meterReadings).getStatusCode())
+                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 
-  @Test
-  public void givenEmptyMeterReadingShouldReturnErrorResponse() {
-    MeterReadings meterReadings = new MeterReadings(SMART_METER_ID, Collections.emptyList());
-    assertThat(meterReadingController.storeReadings(meterReadings).getStatusCode())
-        .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-  }
+    @Test
+    public void givenEmptyMeterReadingShouldReturnErrorResponse() {
+        MeterReadings meterReadings = new MeterReadings(SMART_METER_ID, Collections.emptyList());
+        assertThat(meterReadingController.storeReadings(meterReadings).getStatusCode())
+                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 
-  @Test
-  public void givenNullReadingsAreSuppliedWhenStoringShouldReturnErrorResponse() {
-    MeterReadings meterReadings = new MeterReadings(SMART_METER_ID, null);
-    assertThat(meterReadingController.storeReadings(meterReadings).getStatusCode())
-        .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-  }
+    @Test
+    public void givenNullReadingsAreSuppliedWhenStoringShouldReturnErrorResponse() {
+        MeterReadings meterReadings = new MeterReadings(SMART_METER_ID, null);
+        assertThat(meterReadingController.storeReadings(meterReadings).getStatusCode())
+                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 
-  @Test
-  public void givenMultipleBatchesOfMeterReadingsShouldStore() {
-    MeterReadings meterReadings =
-        new MeterReadingsBuilder()
-            .setSmartMeterId(SMART_METER_ID)
-            .generateElectricityReadings()
-            .build();
+    @Test
+    public void givenMultipleBatchesOfMeterReadingsShouldStore() {
+        MeterReadings meterReadings = new MeterReadingsBuilder()
+                .setSmartMeterId(SMART_METER_ID)
+                .generateElectricityReadings()
+                .build();
 
-    MeterReadings otherMeterReadings =
-        new MeterReadingsBuilder()
-            .setSmartMeterId(SMART_METER_ID)
-            .generateElectricityReadings()
-            .build();
+        MeterReadings otherMeterReadings = new MeterReadingsBuilder()
+                .setSmartMeterId(SMART_METER_ID)
+                .generateElectricityReadings()
+                .build();
 
-    meterReadingController.storeReadings(meterReadings);
-    meterReadingController.storeReadings(otherMeterReadings);
+        meterReadingController.storeReadings(meterReadings);
+        meterReadingController.storeReadings(otherMeterReadings);
 
-    List<ElectricityReading> expectedElectricityReadings = new ArrayList<>();
-    expectedElectricityReadings.addAll(meterReadings.electricityReadings());
-    expectedElectricityReadings.addAll(otherMeterReadings.electricityReadings());
+        List<ElectricityReading> expectedElectricityReadings = new ArrayList<>();
+        expectedElectricityReadings.addAll(meterReadings.electricityReadings());
+        expectedElectricityReadings.addAll(otherMeterReadings.electricityReadings());
 
-    assertThat(meterReadingService.getReadings(SMART_METER_ID).get())
-        .isEqualTo(expectedElectricityReadings);
-  }
+        assertThat(meterReadingService.getReadings(SMART_METER_ID).get()).isEqualTo(expectedElectricityReadings);
+    }
 
-  @Test
-  public void givenMeterReadingsAssociatedWithTheUserShouldStoreAssociatedWithUser() {
-    MeterReadings meterReadings =
-        new MeterReadingsBuilder()
-            .setSmartMeterId(SMART_METER_ID)
-            .generateElectricityReadings()
-            .build();
+    @Test
+    public void givenMeterReadingsAssociatedWithTheUserShouldStoreAssociatedWithUser() {
+        MeterReadings meterReadings = new MeterReadingsBuilder()
+                .setSmartMeterId(SMART_METER_ID)
+                .generateElectricityReadings()
+                .build();
 
-    MeterReadings otherMeterReadings =
-        new MeterReadingsBuilder().setSmartMeterId("00001").generateElectricityReadings().build();
+        MeterReadings otherMeterReadings = new MeterReadingsBuilder()
+                .setSmartMeterId("00001")
+                .generateElectricityReadings()
+                .build();
 
-    meterReadingController.storeReadings(meterReadings);
-    meterReadingController.storeReadings(otherMeterReadings);
+        meterReadingController.storeReadings(meterReadings);
+        meterReadingController.storeReadings(otherMeterReadings);
 
-    assertThat(meterReadingService.getReadings(SMART_METER_ID).get())
-        .isEqualTo(meterReadings.electricityReadings());
-  }
+        assertThat(meterReadingService.getReadings(SMART_METER_ID).get())
+                .isEqualTo(meterReadings.electricityReadings());
+    }
 
-  @Test
-  public void givenMeterIdThatIsNotRecognisedShouldReturnNotFound() {
-    assertThat(meterReadingController.readReadings(SMART_METER_ID).getStatusCode())
-        .isEqualTo(HttpStatus.NOT_FOUND);
-  }
+    @Test
+    public void givenMeterIdThatIsNotRecognisedShouldReturnNotFound() {
+        assertThat(meterReadingController.readReadings(SMART_METER_ID).getStatusCode())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
 }

--- a/src/test/java/uk/tw/energy/controller/PricePlanComparatorControllerTest.java
+++ b/src/test/java/uk/tw/energy/controller/PricePlanComparatorControllerTest.java
@@ -19,111 +19,101 @@ import uk.tw.energy.service.MeterReadingService;
 import uk.tw.energy.service.PricePlanService;
 
 public class PricePlanComparatorControllerTest {
-  private static final String WORST_PLAN_ID = "worst-supplier";
-  private static final String BEST_PLAN_ID = "best-supplier";
-  private static final String SECOND_BEST_PLAN_ID = "second-best-supplier";
-  private static final String SMART_METER_ID = "smart-meter-id";
-  private PricePlanComparatorController controller;
-  private MeterReadingService meterReadingService;
-  private AccountService accountService;
+    private static final String WORST_PLAN_ID = "worst-supplier";
+    private static final String BEST_PLAN_ID = "best-supplier";
+    private static final String SECOND_BEST_PLAN_ID = "second-best-supplier";
+    private static final String SMART_METER_ID = "smart-meter-id";
+    private PricePlanComparatorController controller;
+    private MeterReadingService meterReadingService;
+    private AccountService accountService;
 
-  @BeforeEach
-  public void setUp() {
-    meterReadingService = new MeterReadingService(new HashMap<>());
+    @BeforeEach
+    public void setUp() {
+        meterReadingService = new MeterReadingService(new HashMap<>());
 
-    PricePlan pricePlan1 = new PricePlan(WORST_PLAN_ID, null, BigDecimal.TEN, null);
-    PricePlan pricePlan2 = new PricePlan(BEST_PLAN_ID, null, BigDecimal.ONE, null);
-    PricePlan pricePlan3 = new PricePlan(SECOND_BEST_PLAN_ID, null, BigDecimal.valueOf(2), null);
-    List<PricePlan> pricePlans = List.of(pricePlan1, pricePlan2, pricePlan3);
-    PricePlanService pricePlanService = new PricePlanService(pricePlans, meterReadingService);
+        PricePlan pricePlan1 = new PricePlan(WORST_PLAN_ID, null, BigDecimal.TEN, null);
+        PricePlan pricePlan2 = new PricePlan(BEST_PLAN_ID, null, BigDecimal.ONE, null);
+        PricePlan pricePlan3 = new PricePlan(SECOND_BEST_PLAN_ID, null, BigDecimal.valueOf(2), null);
+        List<PricePlan> pricePlans = List.of(pricePlan1, pricePlan2, pricePlan3);
+        PricePlanService pricePlanService = new PricePlanService(pricePlans, meterReadingService);
 
-    accountService = new AccountService(Map.of(SMART_METER_ID, WORST_PLAN_ID));
+        accountService = new AccountService(Map.of(SMART_METER_ID, WORST_PLAN_ID));
 
-    controller = new PricePlanComparatorController(pricePlanService, accountService);
-  }
+        controller = new PricePlanComparatorController(pricePlanService, accountService);
+    }
 
-  @Test
-  public void calculatedCostForEachPricePlan_happyPath() {
-    var electricityReading =
-        new ElectricityReading(Instant.now().minusSeconds(3600), BigDecimal.valueOf(15.0));
-    var otherReading = new ElectricityReading(Instant.now(), BigDecimal.valueOf(5.0));
-    meterReadingService.storeReadings(SMART_METER_ID, List.of(electricityReading, otherReading));
+    @Test
+    public void calculatedCostForEachPricePlan_happyPath() {
+        var electricityReading = new ElectricityReading(Instant.now().minusSeconds(3600), BigDecimal.valueOf(15.0));
+        var otherReading = new ElectricityReading(Instant.now(), BigDecimal.valueOf(5.0));
+        meterReadingService.storeReadings(SMART_METER_ID, List.of(electricityReading, otherReading));
 
-    ResponseEntity<Map<String, Object>> response =
-        controller.calculatedCostForEachPricePlan(SMART_METER_ID);
+        ResponseEntity<Map<String, Object>> response = controller.calculatedCostForEachPricePlan(SMART_METER_ID);
 
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    Map<String, Object> expected =
-        Map.of(
-            PricePlanComparatorController.PRICE_PLAN_ID_KEY,
-            WORST_PLAN_ID,
-            PricePlanComparatorController.PRICE_PLAN_COMPARISONS_KEY,
-            Map.of(
-                WORST_PLAN_ID, BigDecimal.valueOf(100.0),
-                BEST_PLAN_ID, BigDecimal.valueOf(10.0),
-                SECOND_BEST_PLAN_ID, BigDecimal.valueOf(20.0)));
-    assertThat(response.getBody()).isEqualTo(expected);
-  }
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<String, Object> expected = Map.of(
+                PricePlanComparatorController.PRICE_PLAN_ID_KEY,
+                WORST_PLAN_ID,
+                PricePlanComparatorController.PRICE_PLAN_COMPARISONS_KEY,
+                Map.of(
+                        WORST_PLAN_ID, BigDecimal.valueOf(100.0),
+                        BEST_PLAN_ID, BigDecimal.valueOf(10.0),
+                        SECOND_BEST_PLAN_ID, BigDecimal.valueOf(20.0)));
+        assertThat(response.getBody()).isEqualTo(expected);
+    }
 
-  @Test
-  public void calculatedCostForEachPricePlan_noReadings() {
-    ResponseEntity<Map<String, Object>> response =
-        controller.calculatedCostForEachPricePlan("not-found");
+    @Test
+    public void calculatedCostForEachPricePlan_noReadings() {
+        ResponseEntity<Map<String, Object>> response = controller.calculatedCostForEachPricePlan("not-found");
 
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-  }
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
 
-  @Test
-  public void recommendCheapestPricePlans_noLimit() {
-    var electricityReading =
-        new ElectricityReading(Instant.now().minusSeconds(1800), BigDecimal.valueOf(35.0));
-    var otherReading = new ElectricityReading(Instant.now(), BigDecimal.valueOf(3.0));
-    meterReadingService.storeReadings(SMART_METER_ID, List.of(electricityReading, otherReading));
+    @Test
+    public void recommendCheapestPricePlans_noLimit() {
+        var electricityReading = new ElectricityReading(Instant.now().minusSeconds(1800), BigDecimal.valueOf(35.0));
+        var otherReading = new ElectricityReading(Instant.now(), BigDecimal.valueOf(3.0));
+        meterReadingService.storeReadings(SMART_METER_ID, List.of(electricityReading, otherReading));
 
-    ResponseEntity<List<Map.Entry<String, BigDecimal>>> response =
-        controller.recommendCheapestPricePlans(SMART_METER_ID, null);
+        ResponseEntity<List<Map.Entry<String, BigDecimal>>> response =
+                controller.recommendCheapestPricePlans(SMART_METER_ID, null);
 
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    var expectedPricePlanToCost =
-        List.of(
-            new AbstractMap.SimpleEntry<>(BEST_PLAN_ID, BigDecimal.valueOf(38.0)),
-            new AbstractMap.SimpleEntry<>(SECOND_BEST_PLAN_ID, BigDecimal.valueOf(76.0)),
-            new AbstractMap.SimpleEntry<>(WORST_PLAN_ID, BigDecimal.valueOf(380.0)));
-    assertThat(response.getBody()).isEqualTo(expectedPricePlanToCost);
-  }
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        var expectedPricePlanToCost = List.of(
+                new AbstractMap.SimpleEntry<>(BEST_PLAN_ID, BigDecimal.valueOf(38.0)),
+                new AbstractMap.SimpleEntry<>(SECOND_BEST_PLAN_ID, BigDecimal.valueOf(76.0)),
+                new AbstractMap.SimpleEntry<>(WORST_PLAN_ID, BigDecimal.valueOf(380.0)));
+        assertThat(response.getBody()).isEqualTo(expectedPricePlanToCost);
+    }
 
-  @Test
-  public void recommendCheapestPricePlans_withLimit() {
-    var electricityReading =
-        new ElectricityReading(Instant.now().minusSeconds(2700), BigDecimal.valueOf(5.0));
-    var otherReading = new ElectricityReading(Instant.now(), BigDecimal.valueOf(20.0));
-    meterReadingService.storeReadings(SMART_METER_ID, List.of(electricityReading, otherReading));
+    @Test
+    public void recommendCheapestPricePlans_withLimit() {
+        var electricityReading = new ElectricityReading(Instant.now().minusSeconds(2700), BigDecimal.valueOf(5.0));
+        var otherReading = new ElectricityReading(Instant.now(), BigDecimal.valueOf(20.0));
+        meterReadingService.storeReadings(SMART_METER_ID, List.of(electricityReading, otherReading));
 
-    ResponseEntity<List<Map.Entry<String, BigDecimal>>> response =
-        controller.recommendCheapestPricePlans(SMART_METER_ID, 2);
+        ResponseEntity<List<Map.Entry<String, BigDecimal>>> response =
+                controller.recommendCheapestPricePlans(SMART_METER_ID, 2);
 
-    var expectedPricePlanToCost =
-        List.of(
-            new AbstractMap.SimpleEntry<>(BEST_PLAN_ID, BigDecimal.valueOf(16.7)),
-            new AbstractMap.SimpleEntry<>(SECOND_BEST_PLAN_ID, BigDecimal.valueOf(33.4)));
-    assertThat(response.getBody()).isEqualTo(expectedPricePlanToCost);
-  }
+        var expectedPricePlanToCost = List.of(
+                new AbstractMap.SimpleEntry<>(BEST_PLAN_ID, BigDecimal.valueOf(16.7)),
+                new AbstractMap.SimpleEntry<>(SECOND_BEST_PLAN_ID, BigDecimal.valueOf(33.4)));
+        assertThat(response.getBody()).isEqualTo(expectedPricePlanToCost);
+    }
 
-  @Test
-  public void recommendCheapestPricePlans_limitHigherThanNumberOfEntries() {
-    var reading0 =
-        new ElectricityReading(Instant.now().minusSeconds(3600), BigDecimal.valueOf(25.0));
-    var reading1 = new ElectricityReading(Instant.now(), BigDecimal.valueOf(3.0));
-    meterReadingService.storeReadings(SMART_METER_ID, List.of(reading0, reading1));
+    @Test
+    public void recommendCheapestPricePlans_limitHigherThanNumberOfEntries() {
+        var reading0 = new ElectricityReading(Instant.now().minusSeconds(3600), BigDecimal.valueOf(25.0));
+        var reading1 = new ElectricityReading(Instant.now(), BigDecimal.valueOf(3.0));
+        meterReadingService.storeReadings(SMART_METER_ID, List.of(reading0, reading1));
 
-    ResponseEntity<List<Map.Entry<String, BigDecimal>>> response =
-        controller.recommendCheapestPricePlans(SMART_METER_ID, 5);
+        ResponseEntity<List<Map.Entry<String, BigDecimal>>> response =
+                controller.recommendCheapestPricePlans(SMART_METER_ID, 5);
 
-    var expectedPricePlanToCost =
-        List.of(
-            new AbstractMap.SimpleEntry<>(BEST_PLAN_ID, BigDecimal.valueOf(14.0)),
-            new AbstractMap.SimpleEntry<>(SECOND_BEST_PLAN_ID, BigDecimal.valueOf(28.0)),
-            new AbstractMap.SimpleEntry<>(WORST_PLAN_ID, BigDecimal.valueOf(140.0)));
-    assertThat(response.getBody()).isEqualTo(expectedPricePlanToCost);
-  }
+        var expectedPricePlanToCost = List.of(
+                new AbstractMap.SimpleEntry<>(BEST_PLAN_ID, BigDecimal.valueOf(14.0)),
+                new AbstractMap.SimpleEntry<>(SECOND_BEST_PLAN_ID, BigDecimal.valueOf(28.0)),
+                new AbstractMap.SimpleEntry<>(WORST_PLAN_ID, BigDecimal.valueOf(140.0)));
+        assertThat(response.getBody()).isEqualTo(expectedPricePlanToCost);
+    }
 }

--- a/src/test/java/uk/tw/energy/domain/PricePlanTest.java
+++ b/src/test/java/uk/tw/energy/domain/PricePlanTest.java
@@ -14,54 +14,52 @@ import org.junit.jupiter.api.Test;
 
 public class PricePlanTest {
 
-  private final String ENERGY_SUPPLIER_NAME = "Energy Supplier Name";
+    private final String ENERGY_SUPPLIER_NAME = "Energy Supplier Name";
 
-  @Test
-  public void shouldReturnTheEnergySupplierGivenInTheConstructor() {
-    PricePlan pricePlan = new PricePlan(null, ENERGY_SUPPLIER_NAME, null, null);
+    @Test
+    public void shouldReturnTheEnergySupplierGivenInTheConstructor() {
+        PricePlan pricePlan = new PricePlan(null, ENERGY_SUPPLIER_NAME, null, null);
 
-    assertThat(pricePlan.getEnergySupplier()).isEqualTo(ENERGY_SUPPLIER_NAME);
-  }
+        assertThat(pricePlan.getEnergySupplier()).isEqualTo(ENERGY_SUPPLIER_NAME);
+    }
 
-  @Test
-  public void shouldReturnTheBasePriceGivenAnOrdinaryDateTime() throws Exception {
-    LocalDateTime normalDateTime = LocalDateTime.of(2017, Month.AUGUST, 31, 12, 0, 0);
-    PricePlan.PeakTimeMultiplier peakTimeMultiplier =
-        new PricePlan.PeakTimeMultiplier(DayOfWeek.WEDNESDAY, BigDecimal.TEN);
-    PricePlan pricePlan =
-        new PricePlan(null, null, BigDecimal.ONE, singletonList(peakTimeMultiplier));
+    @Test
+    public void shouldReturnTheBasePriceGivenAnOrdinaryDateTime() throws Exception {
+        LocalDateTime normalDateTime = LocalDateTime.of(2017, Month.AUGUST, 31, 12, 0, 0);
+        PricePlan.PeakTimeMultiplier peakTimeMultiplier =
+                new PricePlan.PeakTimeMultiplier(DayOfWeek.WEDNESDAY, BigDecimal.TEN);
+        PricePlan pricePlan = new PricePlan(null, null, BigDecimal.ONE, singletonList(peakTimeMultiplier));
 
-    BigDecimal price = pricePlan.getPrice(normalDateTime);
+        BigDecimal price = pricePlan.getPrice(normalDateTime);
 
-    assertThat(price).isCloseTo(BigDecimal.ONE, Percentage.withPercentage(1));
-  }
+        assertThat(price).isCloseTo(BigDecimal.ONE, Percentage.withPercentage(1));
+    }
 
-  @Test
-  public void shouldReturnAnExceptionPriceGivenExceptionalDateTime() throws Exception {
-    LocalDateTime exceptionalDateTime = LocalDateTime.of(2017, Month.AUGUST, 30, 23, 0, 0);
-    PricePlan.PeakTimeMultiplier peakTimeMultiplier =
-        new PricePlan.PeakTimeMultiplier(DayOfWeek.WEDNESDAY, BigDecimal.TEN);
-    PricePlan pricePlan =
-        new PricePlan(null, null, BigDecimal.ONE, singletonList(peakTimeMultiplier));
+    @Test
+    public void shouldReturnAnExceptionPriceGivenExceptionalDateTime() throws Exception {
+        LocalDateTime exceptionalDateTime = LocalDateTime.of(2017, Month.AUGUST, 30, 23, 0, 0);
+        PricePlan.PeakTimeMultiplier peakTimeMultiplier =
+                new PricePlan.PeakTimeMultiplier(DayOfWeek.WEDNESDAY, BigDecimal.TEN);
+        PricePlan pricePlan = new PricePlan(null, null, BigDecimal.ONE, singletonList(peakTimeMultiplier));
 
-    BigDecimal price = pricePlan.getPrice(exceptionalDateTime);
+        BigDecimal price = pricePlan.getPrice(exceptionalDateTime);
 
-    assertThat(price).isCloseTo(BigDecimal.TEN, Percentage.withPercentage(1));
-  }
+        assertThat(price).isCloseTo(BigDecimal.TEN, Percentage.withPercentage(1));
+    }
 
-  @Test
-  public void shouldReceiveMultipleExceptionalDateTimes() throws Exception {
-    LocalDateTime exceptionalDateTime = LocalDateTime.of(2017, Month.AUGUST, 30, 23, 0, 0);
-    PricePlan.PeakTimeMultiplier peakTimeMultiplier =
-        new PricePlan.PeakTimeMultiplier(DayOfWeek.WEDNESDAY, BigDecimal.TEN);
-    PricePlan.PeakTimeMultiplier otherPeakTimeMultiplier =
-        new PricePlan.PeakTimeMultiplier(DayOfWeek.TUESDAY, BigDecimal.TEN);
-    List<PricePlan.PeakTimeMultiplier> peakTimeMultipliers =
-        Arrays.asList(peakTimeMultiplier, otherPeakTimeMultiplier);
-    PricePlan pricePlan = new PricePlan(null, null, BigDecimal.ONE, peakTimeMultipliers);
+    @Test
+    public void shouldReceiveMultipleExceptionalDateTimes() throws Exception {
+        LocalDateTime exceptionalDateTime = LocalDateTime.of(2017, Month.AUGUST, 30, 23, 0, 0);
+        PricePlan.PeakTimeMultiplier peakTimeMultiplier =
+                new PricePlan.PeakTimeMultiplier(DayOfWeek.WEDNESDAY, BigDecimal.TEN);
+        PricePlan.PeakTimeMultiplier otherPeakTimeMultiplier =
+                new PricePlan.PeakTimeMultiplier(DayOfWeek.TUESDAY, BigDecimal.TEN);
+        List<PricePlan.PeakTimeMultiplier> peakTimeMultipliers =
+                Arrays.asList(peakTimeMultiplier, otherPeakTimeMultiplier);
+        PricePlan pricePlan = new PricePlan(null, null, BigDecimal.ONE, peakTimeMultipliers);
 
-    BigDecimal price = pricePlan.getPrice(exceptionalDateTime);
+        BigDecimal price = pricePlan.getPrice(exceptionalDateTime);
 
-    assertThat(price).isCloseTo(BigDecimal.TEN, Percentage.withPercentage(1));
-  }
+        assertThat(price).isCloseTo(BigDecimal.TEN, Percentage.withPercentage(1));
+    }
 }

--- a/src/test/java/uk/tw/energy/service/AccountServiceTest.java
+++ b/src/test/java/uk/tw/energy/service/AccountServiceTest.java
@@ -9,22 +9,21 @@ import org.junit.jupiter.api.Test;
 
 public class AccountServiceTest {
 
-  private static final String PRICE_PLAN_ID = "price-plan-id";
-  private static final String SMART_METER_ID = "smart-meter-id";
+    private static final String PRICE_PLAN_ID = "price-plan-id";
+    private static final String SMART_METER_ID = "smart-meter-id";
 
-  private AccountService accountService;
+    private AccountService accountService;
 
-  @BeforeEach
-  public void setUp() {
-    Map<String, String> smartMeterToPricePlanAccounts = new HashMap<>();
-    smartMeterToPricePlanAccounts.put(SMART_METER_ID, PRICE_PLAN_ID);
+    @BeforeEach
+    public void setUp() {
+        Map<String, String> smartMeterToPricePlanAccounts = new HashMap<>();
+        smartMeterToPricePlanAccounts.put(SMART_METER_ID, PRICE_PLAN_ID);
 
-    accountService = new AccountService(smartMeterToPricePlanAccounts);
-  }
+        accountService = new AccountService(smartMeterToPricePlanAccounts);
+    }
 
-  @Test
-  public void givenTheSmartMeterIdReturnsThePricePlanId() throws Exception {
-    assertThat(accountService.getPricePlanIdForSmartMeterId(SMART_METER_ID))
-        .isEqualTo(PRICE_PLAN_ID);
-  }
+    @Test
+    public void givenTheSmartMeterIdReturnsThePricePlanId() throws Exception {
+        assertThat(accountService.getPricePlanIdForSmartMeterId(SMART_METER_ID)).isEqualTo(PRICE_PLAN_ID);
+    }
 }

--- a/src/test/java/uk/tw/energy/service/MeterReadingServiceTest.java
+++ b/src/test/java/uk/tw/energy/service/MeterReadingServiceTest.java
@@ -10,22 +10,21 @@ import org.junit.jupiter.api.Test;
 
 public class MeterReadingServiceTest {
 
-  private MeterReadingService meterReadingService;
+    private MeterReadingService meterReadingService;
 
-  @BeforeEach
-  public void setUp() {
-    meterReadingService = new MeterReadingService(new HashMap<>());
-  }
+    @BeforeEach
+    public void setUp() {
+        meterReadingService = new MeterReadingService(new HashMap<>());
+    }
 
-  @Test
-  public void givenMeterIdThatDoesNotExistShouldReturnNull() {
-    assertThat(meterReadingService.getReadings("unknown-id")).isEqualTo(Optional.empty());
-  }
+    @Test
+    public void givenMeterIdThatDoesNotExistShouldReturnNull() {
+        assertThat(meterReadingService.getReadings("unknown-id")).isEqualTo(Optional.empty());
+    }
 
-  @Test
-  public void givenMeterReadingThatExistsShouldReturnMeterReadings() {
-    meterReadingService.storeReadings("random-id", new ArrayList<>());
-    assertThat(meterReadingService.getReadings("random-id"))
-        .isEqualTo(Optional.of(new ArrayList<>()));
-  }
+    @Test
+    public void givenMeterReadingThatExistsShouldReturnMeterReadings() {
+        meterReadingService.storeReadings("random-id", new ArrayList<>());
+        assertThat(meterReadingService.getReadings("random-id")).isEqualTo(Optional.of(new ArrayList<>()));
+    }
 }


### PR DESCRIPTION

## What is being fixed - and why?

The current format forced by the Spotless plugin is the Google format, that indents to 2 spaces.  IntelliJ default is 4 spaces, which makes it awkward to work in the codebase.

I can also say that the Google format breaks lines too much, making them harder to read, at least the way I am used to read code.

I think we should avoid adding distractions to the interview by using an unusual format in the codebase.

## What has changed?

I moved to the Palantir format, that mostly is the same as the one IntelliJ uses by default.  The order of imports is different, but this should be a difficulty for the interviewer or the candidate.
