### PR TITLE
doc - remove Story section as trello is not used anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,24 +22,6 @@ Unfortunately, two members of the team are on annual leave, and another one has 
 another ThoughtWorker to progress with the current user stories on the story wall. This is your chance to make an impact
 on the business, improve the code base and deliver value.
 
-## Story Wall
-
-At JOI energy the development team use a story wall or Kanban board to keep track of features or "stories" as they are
-worked on.
-
-The wall you will be working from today has 7 columns:
-
-- Backlog
-- Ready for Dev
-- In Dev
-- Ready for Testing
-- In Testing
-- Ready for sign off
-- Done
-
-Examples can be found
-here [https://leankit.com/learn/kanban/kanban-board/](https://leankit.com/learn/kanban/kanban-board/)
-
 ## Users
 
 To trial the new JOI software 5 people from the JOI accounts team have agreed to test the service and share their energy


### PR DESCRIPTION
## What is being fixed - and why?

As we've stopped using Trello as story wall, the [Story Wall] section in the README should also be removed for consistency.
The conversation with context can be found here: https://chat.google.com/room/AAAAehaYZT8/X0moxBQI5mM/X0moxBQI5mM?cls=10

## What has changed?
Removed the [Story Wall] section of README.md file.
