### PR TITLE
Add parameters flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,10 @@ idea {
     }
 }
 
+tasks.withType<JavaCompile> {
+    options.compilerArgs.add("-parameters")
+}
+
 val functionalTestImplementation: Configuration by configurations.getting {
     extendsFrom(configurations.implementation.get())
 }
@@ -58,16 +62,16 @@ val functionalTest = task<Test>("functionalTest") {
     useJUnitPlatform()
 
     testLogging {
-        events ("failed", "passed", "skipped", "standard_out")
+        events("failed", "passed", "skipped", "standard_out")
     }
 }
 
 
 dependencies {
     /* Spring Boot */
-    implementation ("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
-        exclude (group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
 }
 
@@ -75,7 +79,7 @@ tasks.named<Test>("test") {
     useJUnitPlatform()
 
     testLogging {
-        events ("failed", "passed", "skipped", "standard_out")
+        events("failed", "passed", "skipped", "standard_out")
     }
 }
 
@@ -92,7 +96,7 @@ tasks.withType<DependencyUpdatesTask> {
     rejectVersionIf {
         isNonStable(candidate.version)
     }
-    gradleReleaseChannel="current"
+    gradleReleaseChannel = "current"
 }
 
 spotless {


### PR DESCRIPTION
## What is being fixed - and why?

Add parameters flag for compilation options. Currently we depend on ide to do that. This fails in eclipse if not done. So instead we put this flag in build itself.

## What has changed?
Added parameters in compilation phase. Applied spotless.
